### PR TITLE
Getting price when currentPrice is not available

### DIFF
--- a/yahoo-stock-prices.js
+++ b/yahoo-stock-prices.js
@@ -28,7 +28,10 @@ module.exports.getCurrentPrice = function (ticker, callback) {
 		if (err) { callback(err); }
 
 		try {
-			var price = parseFloat(body.split("currentPrice")[1].split("fmt\":\"")[1].split("\"")[0]);
+			var price = parseFloat(body.split(`"${ticker}":{"sourceInterval"`)[1]
+				.split("regularMarketPrice")[1]
+				.split("fmt\":\"")[1]
+				.split("\"")[0]);
 
 			callback(null, price);
 		} catch (err) {


### PR DESCRIPTION
I don't know why, but some stocks doesn't load price with the currentPrice property, for example 'VINO11.SA'. So I've founded another way to get the price that seens to work properly with both cases.