### PR TITLE
Don't convert currency to uppercase

### DIFF
--- a/tests/yahoo-stock-prices.spec.js
+++ b/tests/yahoo-stock-prices.spec.js
@@ -50,7 +50,7 @@ describe('yahoo-stock-prices', () => {
         test.each(
             [
                 ['AAPL', { currency: 'USD' }],
-                ['IAG.L', { currency: 'GBP' }],
+                ['IAG.L', { currency: 'GBp' }],
                 ['TSLA.MX', { currency: 'MXN' }],
                 ['DTE.DE', { currency: 'EUR' }],
             ],

--- a/yahoo-stock-prices.js
+++ b/yahoo-stock-prices.js
@@ -79,7 +79,7 @@ const getCurrentData = function (ticker) {
                 const currencyMatch = body.match(/Currency in ([A-Za-z]{3})/);
                 let currency = null;
                 if (currencyMatch) {
-                    currency = currencyMatch[1].toUpperCase();
+                    currency = currencyMatch[1];
                 }
 
                 resolve({


### PR DESCRIPTION
It turns out there is a difference between "GBP" and "GBp". Stocks on the London Stock Exchange are priced in "GBp" which is pennies, not "GBP" which is pounds.
Change the code to not convert the currency to upper case. Just leave it as it is on Yahoo.